### PR TITLE
Update to Liberty Maven 2.6.4 and Liberty 19.0.0.3

### DIFF
--- a/RogueCloudClientLiberty/pom.xml
+++ b/RogueCloudClientLiberty/pom.xml
@@ -92,12 +92,12 @@
 			<plugin>
 				<groupId>net.wasdev.wlp.maven.plugins</groupId>
 				<artifactId>liberty-maven-plugin</artifactId>
-				<version>2.1.1</version>
+				<version>2.6.4</version>
 				<configuration>
 					<assemblyArtifact>
 						<groupId>com.ibm.websphere.appserver.runtime</groupId>
 						<artifactId>wlp-webProfile7</artifactId>
-						<version>17.0.0.3</version>
+						<version>19.0.0.3</version>
 						<type>zip</type>
 					</assemblyArtifact>
 					<configFile>${basedir}/files/server.xml</configFile>

--- a/RogueCloudServer/pom.xml
+++ b/RogueCloudServer/pom.xml
@@ -131,12 +131,12 @@
 			<plugin>
 				<groupId>net.wasdev.wlp.maven.plugins</groupId>
 				<artifactId>liberty-maven-plugin</artifactId>
-				<version>2.1.1</version>
+				<version>2.6.4</version>
 				<configuration>
 					<assemblyArtifact>
 						<groupId>com.ibm.websphere.appserver.runtime</groupId>
 						<artifactId>wlp-webProfile7</artifactId>
-						<version>17.0.0.3</version>
+						<version>19.0.0.3</version>
 						<type>zip</type>
 					</assemblyArtifact>
 					<configFile>${basedir}/files/server.xml</configFile>


### PR DESCRIPTION
Update to Liberty Maven plugin v2.6.4 and Liberty v19.0.0.3, which should fix any issues when using Java 9+.